### PR TITLE
XEP-0388: Add user-agent element

### DIFF
--- a/xep-0388.xml
+++ b/xep-0388.xml
@@ -170,10 +170,15 @@
   <section2 topic="Initiation" anchor="initiation">
     <p>Clients, upon observing this stream feature, initiate the authentication by the use of the &lt;authenticate/> top-level element within the same namespace. The nature of this element is to inform the server about properties of the final stream state, as well as initiate authentication itself and possibly ask for an upgrade task for the server-supported SASL mechanisms. To achieve this, it has a single mandatory attribute of "mechanism", with a string value of a mechanism name offered by the Server in the stream feature, an optional attribute of "upgrade", with a string value of a mechanism offered by the Server in an &lt;upgrade/> element in the stream feature, and an optional child element of &lt;initial-response/>, containing a base64-encoded SASL Initial Response. If the "mechanism" or "upgrade" attributes contain a string not previously announced by the server in in the stream feature, the server MUST fail the authentication.</p>
     <p>If the stream's from attribute (if present) does not match the non-empty authorization string, the server MUST fail the authentication.</p>
+    <p>Clients SHOULD also include a &lt;user-agent/> element, informing the server about the connecting client. The 'id' attribute is RECOMMENDED, and if present it contains a unique stable identifier for the client installation. This allows the server to provide functionality such as deriving stable resource identifiers (see &xep0386;). The child elements &lt;software/> and &lt;device/> contain text descriptions of the client software and the device it is installed on. These allow the server to keep the user informed about what devices are connected to their account. Servers MUST NOT expose this information to other entities (such functionality is available in &xep0092; if required).</p>
     <example caption="An authentication request"><![CDATA[
 <authenticate xmlns='urn:xmpp:sasl:2' mechanism="SCRAM-SHA-1-PLUS" upgrade="SCRAM-SHA-256">
   <!-- Base64 of: 'p=tls-exporter,,n=user,r=12C4CD5C-E38E-4A98-8F6D-15C38F51CCC6' -->
   <initial-response>cD10bHMtZXhwb3J0ZXIsLG49dXNlcixyPTEyQzRDRDVDLUUzOEUtNEE5OC04RjZELTE1QzM4RjUxQ0NDNg==</initial-response>
+  <user-agent id="d4565fa7-4d72-4749-b3d3-740edbf87770">
+    <software>AwesomeXMPP</software>
+    <device>Kiva's Phone</device>
+  </user-agent>
 </authenticate>
 ]]></example>
     <p>In order to provide support for other desired stream states beyond authentication, additional child elements are used. For example, a hypothetical XEP-0198 session resumption element might be included, and/or Resource Binding requests.</p>
@@ -182,6 +187,10 @@
   <initial-response>
     SSBzaG91bGQgbWFrZSB0aGlzIGEgY29tcGV0aXRpb24=
   </initial-response>
+  <user-agent id="d4565fa7-4d72-4749-b3d3-740edbf87770">
+    <software>AwesomeXMPP</software>
+    <device>Kiva's Phone</device>
+  </user-agent>
   <bind xmlns='urn:xmpp:bind:example'/>
 </authenticate>
 ]]></example>
@@ -463,6 +472,10 @@
 -->
 <authenticate xmlns='urn:xmpp:sasl:2' mechanism='PLAIN'>
   <initial-response>AGFsaWNlQGV4YW1wbGUub3JnCjM0NQ==</initial-response>
+  <user-agent id="d4565fa7-4d72-4749-b3d3-740edbf87770">
+    <software>AwesomeXMPP</software>
+    <device>Kiva's Phone</device>
+  </user-agent>
 </authenticate>
 
 <!--
@@ -507,6 +520,10 @@
   Here, no initial response is needed, so none is sent.
 -->
 <authenticate xmlns='urn:xmpp:sasl:2' mechanism='CRAM-MD5'>
+  <user-agent id="d4565fa7-4d72-4749-b3d3-740edbf87770">
+    <software>AwesomeXMPP</software>
+    <device>Kiva's Phone</device>
+  </user-agent>
 </authenticate>
 
 <!--
@@ -566,6 +583,10 @@
   <initial-response>
     SW5pdGlhbCBSZXNwb25zZQ==
   </initial-response>
+  <user-agent id="d4565fa7-4d72-4749-b3d3-740edbf87770">
+    <software>AwesomeXMPP</software>
+    <device>Kiva's Phone</device>
+  </user-agent>
   <megabind xmlns='urn:example:megabind'>
     <resource>this-one-please</resource>
   </megabind>


### PR DESCRIPTION
This serves multiple purposes:

- Provides a stable client identifier for bind2
- Provides human-readable client description for connected device listings or 2FA prompts shown to users
- Eases debugging (what client is this trying and failing to connect?)
- Allows support for per-device passwords without PLAIN

and probably more.