### PR TITLE
XEP-0388: No inline features to be processed on failure

### DIFF
--- a/xep-0388.xml
+++ b/xep-0388.xml
@@ -268,6 +268,7 @@
     </section3>
     <section3 topic="Failure" anchor="failure">
       <p>A &lt;failure/> element is used by the server to terminate the authentication attempt. It MAY contain application-specific error codes, and MAY contain a textual error. It MUST contain one of the SASL error codes from RFC 6120 Section 6.5.</p>
+      <p>The server MUST NOT process any inline features requested by the client in a failed authentication request, if any.</p>
       <example caption="Failure"><![CDATA[
 <failure xmlns='urn:xmpp:sasl:2'>
   <aborted xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/>


### PR DESCRIPTION
Added some text to make clear that the server mustn't process inline feature requests if the authentication fails.